### PR TITLE
Make 2 lists save as 2 files

### DIFF
--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -14,7 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+    private Path addressBookFilePath = Paths.get("data" , "buyers.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.


### PR DESCRIPTION
Uses 2 address books with only buyers and only sellers; address book with only sellers uses a fixed name in the same directory as the original (now buyer-only).

UserPrefs for the seller address book file path is not defined yet, which might lead to unintended behaviour if the file name is changed.