### PR TITLE
Allow flexible filling

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
@@ -7,6 +7,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSE_INFO;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.displayable.Address.DEFAULT_ADDRESS_STRING;
+import static seedu.address.model.displayable.Email.DEFAULT_EMAIL_STRING;
+import static seedu.address.model.displayable.Phone.DEFAULT_PHONE_STRING;
+import static seedu.address.model.displayable.HouseInfo.DEFAULT_HOUSE_INFO;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -36,18 +40,21 @@ public class AddBuyerCommandParser implements Parser<AddBuyerCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_HOUSE_INFO, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSE_INFO)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBuyerCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE,
                 PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_HOUSE_INFO);
-        Name name = ParserUtil.parseName(commandWarnings, argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(commandWarnings, argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(commandWarnings, argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(commandWarnings, argMultimap.getValue(PREFIX_ADDRESS).get());
-        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValue(PREFIX_HOUSE_INFO).get());
+        Name name = ParserUtil.parseName(commandWarnings, argMultimap.getValueOrDefault(PREFIX_NAME, ""));
+        Phone phone = ParserUtil.parsePhone(commandWarnings, argMultimap.getValueOrDefault(PREFIX_PHONE,
+                DEFAULT_PHONE_STRING));
+        Email email = ParserUtil.parseEmail(commandWarnings, argMultimap.getValueOrDefault(PREFIX_EMAIL,
+                DEFAULT_EMAIL_STRING));
+        Address address = ParserUtil.parseAddress(commandWarnings, argMultimap.getValueOrDefault(PREFIX_ADDRESS,
+                DEFAULT_ADDRESS_STRING));
+        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValueOrDefault(PREFIX_HOUSE_INFO,
+                DEFAULT_HOUSE_INFO));
         Set<Tag> tagList = ParserUtil.parseTags(commandWarnings, argMultimap.getAllValues(PREFIX_TAG));
 
         Buyer buyer = new Buyer(name, phone, email, address, houseInfo, tagList);
@@ -60,7 +67,7 @@ public class AddBuyerCommandParser implements Parser<AddBuyerCommand> {
      * {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValueOrDefault(prefix, "") != "");
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddBuyerCommandParser.java
@@ -9,8 +9,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.displayable.Address.DEFAULT_ADDRESS_STRING;
 import static seedu.address.model.displayable.Email.DEFAULT_EMAIL_STRING;
-import static seedu.address.model.displayable.Phone.DEFAULT_PHONE_STRING;
 import static seedu.address.model.displayable.HouseInfo.DEFAULT_HOUSE_INFO;
+import static seedu.address.model.displayable.Phone.DEFAULT_PHONE_STRING;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -47,14 +47,15 @@ public class AddBuyerCommandParser implements Parser<AddBuyerCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE,
                 PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_HOUSE_INFO);
         Name name = ParserUtil.parseName(commandWarnings, argMultimap.getValueOrDefault(PREFIX_NAME, ""));
+        assert name != null && !name.toString().trim().isEmpty() : "All buyers must have names!";
         Phone phone = ParserUtil.parsePhone(commandWarnings, argMultimap.getValueOrDefault(PREFIX_PHONE,
                 DEFAULT_PHONE_STRING));
         Email email = ParserUtil.parseEmail(commandWarnings, argMultimap.getValueOrDefault(PREFIX_EMAIL,
                 DEFAULT_EMAIL_STRING));
         Address address = ParserUtil.parseAddress(commandWarnings, argMultimap.getValueOrDefault(PREFIX_ADDRESS,
                 DEFAULT_ADDRESS_STRING));
-        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValueOrDefault(PREFIX_HOUSE_INFO,
-                DEFAULT_HOUSE_INFO));
+        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValueOrDefault(
+                PREFIX_HOUSE_INFO, DEFAULT_HOUSE_INFO));
         Set<Tag> tagList = ParserUtil.parseTags(commandWarnings, argMultimap.getAllValues(PREFIX_TAG));
 
         Buyer buyer = new Buyer(name, phone, email, address, houseInfo, tagList);

--- a/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
@@ -49,6 +49,7 @@ public class AddSellerCommandParser implements Parser<AddSellerCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_SELLING_ADDRESS);
         Name name = ParserUtil.parseName(commandWarnings, argMultimap.getValueOrDefault(PREFIX_NAME, ""));
+        assert name != null && !name.toString().trim().isEmpty() : "All sellers must have names!";
         Phone phone = ParserUtil.parsePhone(commandWarnings, argMultimap.getValueOrDefault(PREFIX_PHONE,
                 DEFAULT_PHONE_STRING));
         Email email = ParserUtil.parseEmail(commandWarnings, argMultimap.getValueOrDefault(PREFIX_EMAIL,
@@ -57,8 +58,8 @@ public class AddSellerCommandParser implements Parser<AddSellerCommand> {
                 DEFAULT_ADDRESS_STRING));
         Address sellingAddress = ParserUtil.parseAddress(commandWarnings, argMultimap.getValueOrDefault(
                 PREFIX_SELLING_ADDRESS, DEFAULT_ADDRESS_STRING));
-        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValueOrDefault(PREFIX_HOUSE_INFO,
-                DEFAULT_HOUSE_INFO));
+        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValueOrDefault(
+                PREFIX_HOUSE_INFO, DEFAULT_HOUSE_INFO));
         Set<Tag> tagList = ParserUtil.parseTags(commandWarnings, argMultimap.getAllValues(PREFIX_TAG));
 
         Seller seller = new Seller(name, phone, email, address, sellingAddress, houseInfo, tagList);

--- a/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddSellerCommandParser.java
@@ -8,6 +8,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SELLING_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.displayable.Address.DEFAULT_ADDRESS_STRING;
+import static seedu.address.model.displayable.Email.DEFAULT_EMAIL_STRING;
+import static seedu.address.model.displayable.HouseInfo.DEFAULT_HOUSE_INFO;
+import static seedu.address.model.displayable.Phone.DEFAULT_PHONE_STRING;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -38,20 +42,23 @@ public class AddSellerCommandParser implements Parser<AddSellerCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_SELLING_ADDRESS, PREFIX_HOUSE_INFO, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_HOUSE_INFO,
-                PREFIX_SELLING_ADDRESS, PREFIX_EMAIL) || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSellerCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_SELLING_ADDRESS);
-        Name name = ParserUtil.parseName(commandWarnings, argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(commandWarnings, argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(commandWarnings, argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(commandWarnings, argMultimap.getValue(PREFIX_ADDRESS).get());
-        Address sellingAddress =
-                ParserUtil.parseAddress(commandWarnings, argMultimap.getValue(PREFIX_SELLING_ADDRESS).get());
-        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValue(PREFIX_HOUSE_INFO).get());
+        Name name = ParserUtil.parseName(commandWarnings, argMultimap.getValueOrDefault(PREFIX_NAME, ""));
+        Phone phone = ParserUtil.parsePhone(commandWarnings, argMultimap.getValueOrDefault(PREFIX_PHONE,
+                DEFAULT_PHONE_STRING));
+        Email email = ParserUtil.parseEmail(commandWarnings, argMultimap.getValueOrDefault(PREFIX_EMAIL,
+                DEFAULT_EMAIL_STRING));
+        Address address = ParserUtil.parseAddress(commandWarnings, argMultimap.getValueOrDefault(PREFIX_ADDRESS,
+                DEFAULT_ADDRESS_STRING));
+        Address sellingAddress = ParserUtil.parseAddress(commandWarnings, argMultimap.getValueOrDefault(
+                PREFIX_SELLING_ADDRESS, DEFAULT_ADDRESS_STRING));
+        HouseInfo houseInfo = ParserUtil.parseHouseInfo(commandWarnings, argMultimap.getValueOrDefault(PREFIX_HOUSE_INFO,
+                DEFAULT_HOUSE_INFO));
         Set<Tag> tagList = ParserUtil.parseTags(commandWarnings, argMultimap.getAllValues(PREFIX_TAG));
 
         Seller seller = new Seller(name, phone, email, address, sellingAddress, houseInfo, tagList);
@@ -64,7 +71,7 @@ public class AddSellerCommandParser implements Parser<AddSellerCommand> {
      * {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValueOrDefault(prefix, "") != "");
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -36,11 +36,11 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Returns the last value of {@code prefix}.
+     * Returns the last value of {@code prefix} or the default value if it does not exist.
      */
-    public Optional<String> getValue(Prefix prefix) {
+    public String getValueOrDefault(Prefix prefix, String defaultString) {
         List<String> values = getAllValues(prefix);
-        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
+        return values.isEmpty() ? defaultString : values.get(values.size() - 1);
     }
 
     /**
@@ -59,7 +59,7 @@ public class ArgumentMultimap {
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {
-        return getValue(new Prefix("")).orElse("");
+        return getValueOrDefault(new Prefix(""), "");
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -39,8 +39,8 @@ public class ArgumentMultimap {
      */
     public String getValueOrDefault(Prefix prefix, String defaultString) {
         List<String> values = getAllValues(prefix);
-        return !values.isEmpty() && values.get(values.size() - 1) != null &&
-                !values.get(values.size() - 1).trim().isEmpty() ? values.get(values.size() - 1) : defaultString;
+        return !values.isEmpty() && values.get(values.size() - 1) != null
+                && !values.get(values.size() - 1).trim().isEmpty() ? values.get(values.size() - 1) : defaultString;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import seedu.address.logic.Messages;
@@ -40,7 +39,8 @@ public class ArgumentMultimap {
      */
     public String getValueOrDefault(Prefix prefix, String defaultString) {
         List<String> values = getAllValues(prefix);
-        return values.isEmpty() ? defaultString : values.get(values.size() - 1);
+        return !values.isEmpty() && values.get(values.size() - 1) != null &&
+                !values.get(values.size() - 1).trim().isEmpty() ? values.get(values.size() - 1) : defaultString;
     }
 
     /**

--- a/src/main/java/seedu/address/model/displayable/Address.java
+++ b/src/main/java/seedu/address/model/displayable/Address.java
@@ -25,6 +25,7 @@ public class Address {
     //REMOVE THIS if you've resolved this.
     public static final String VALIDATION_REGEX = "[^\\s].*";
     public static final String AFFIRMATION_REGEX = VALIDATION_REGEX;
+    public static final String DEFAULT_ADDRESS_STRING = "Placeholder Street, Singapore";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/displayable/Email.java
+++ b/src/main/java/seedu/address/model/displayable/Email.java
@@ -11,6 +11,7 @@ import seedu.address.commons.util.AppUtil;
 public class Email {
     public static final String MESSAGE_CONSTRAINTS = "Emails must contain at least one '@'.";
     public static final String VALIDATION_REGEX = "[\\S\\s]*@[\\S\\s]*";
+    public static final String DEFAULT_EMAIL_STRING = "default@email.com";
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_RECOMMENDATIONS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
@@ -32,7 +33,7 @@ public class Email {
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String AFFIRMATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
-    public static final String DEFAULT_EMAIL_STRING = "default@email.com";
+
     // A minimally valid email must have at least one @ symbol.
 
     public final String value;

--- a/src/main/java/seedu/address/model/displayable/Email.java
+++ b/src/main/java/seedu/address/model/displayable/Email.java
@@ -32,6 +32,7 @@ public class Email {
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String AFFIRMATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    public static final String DEFAULT_EMAIL_STRING = "default@email.com";
     // A minimally valid email must have at least one @ symbol.
 
     public final String value;

--- a/src/main/java/seedu/address/model/displayable/HouseInfo.java
+++ b/src/main/java/seedu/address/model/displayable/HouseInfo.java
@@ -19,6 +19,7 @@ public class HouseInfo {
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
     public static final String AFFIRMATION_REGEX = VALIDATION_REGEX;
+    public static final String DEFAULT_HOUSE_INFO = "Placeholder house";
     private final String info;
 
     /**

--- a/src/main/java/seedu/address/model/displayable/Phone.java
+++ b/src/main/java/seedu/address/model/displayable/Phone.java
@@ -17,6 +17,7 @@ public class Phone {
                     + "this from the main number.";
     public static final String VALIDATION_REGEX = ".*\\d.*";
     public static final String AFFIRMATION_REGEX = "((\\+\\d{0,3} )?)\\d{3,}";
+    public static final String DEFAULT_PHONE_STRING = "123";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddBuyerCommandParserTest.java
@@ -24,11 +24,6 @@ public class AddBuyerCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBuyerCommand.MESSAGE_USAGE));
     }
     @Test
-    public void assertFailsParse_partialInput() {
-        assertParseFailure(parser, PARTIAL_INPUT,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBuyerCommand.MESSAGE_USAGE));
-    }
-    @Test
     public void assertFailsParse_badFieldsInput() {
         assertParseFailure(parser, BAD_FIELDS_INPUT,
             String.format(Phone.MESSAGE_CONSTRAINTS, AddBuyerCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/AddBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddBuyerCommandParserTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddBuyerCommand;
 import seedu.address.model.displayable.Phone;
+import seedu.address.testutil.BuyerBuilder;
 
 public class AddBuyerCommandParserTest {
     static final String BROKEN_INPUT = "ALASDKJDL";
-    static final String PARTIAL_INPUT = " n/adam p/3094 e/email@com ah/homeaddress";
+    static final String INVALID_PARTIAL_INPUT = " p/3094 e/email@com ah/homeaddress";
+    static final String VALID_PARTIAL_INPUT = " n/adam";
     static final String BAD_FIELDS_INPUT = " n/adam p/badnumber e/email@com ah/homeaddress i/info";
     static final String VALID_INPUT = " n/Alice Pauline p/94351253 e/alice@example.com ah/123, Jurong West Ave 6"
             + ", #08-111 i/Loves views t/friends";
@@ -24,9 +26,19 @@ public class AddBuyerCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBuyerCommand.MESSAGE_USAGE));
     }
     @Test
+    public void assertPassesParse_invalidPartialInput() {
+        assertParseFailure(parser, INVALID_PARTIAL_INPUT,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddBuyerCommand.MESSAGE_USAGE));
+    }
+    @Test
     public void assertFailsParse_badFieldsInput() {
         assertParseFailure(parser, BAD_FIELDS_INPUT,
             String.format(Phone.MESSAGE_CONSTRAINTS, AddBuyerCommand.MESSAGE_USAGE));
+    }
+    @Test
+    public void assertPassesParse_validPartialInput() {
+        assertParseSuccess(parser, VALID_PARTIAL_INPUT,
+                new AddBuyerCommand(new BuyerBuilder().withName("adam").build()));
     }
     @Test
     public void assertPassesParse_validInput() {

--- a/src/test/java/seedu/address/logic/parser/AddSellerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSellerCommandParserTest.java
@@ -7,11 +7,8 @@ import static seedu.address.testutil.TypicalSellers.SALICE;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.AddBuyerCommand;
 import seedu.address.logic.commands.AddSellerCommand;
-import seedu.address.logic.commands.Command;
 import seedu.address.model.displayable.Phone;
-import seedu.address.testutil.BuyerBuilder;
 import seedu.address.testutil.SellerBuilder;
 
 public class AddSellerCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/AddSellerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSellerCommandParserTest.java
@@ -7,12 +7,17 @@ import static seedu.address.testutil.TypicalSellers.SALICE;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.AddBuyerCommand;
 import seedu.address.logic.commands.AddSellerCommand;
+import seedu.address.logic.commands.Command;
 import seedu.address.model.displayable.Phone;
+import seedu.address.testutil.BuyerBuilder;
+import seedu.address.testutil.SellerBuilder;
 
 public class AddSellerCommandParserTest {
     static final String BROKEN_INPUT = "ALASDKJDL";
-    static final String PARTIAL_INPUT = " n/adam p/3094 e/email@com ah/homeaddress";
+    static final String INVALID_PARTIAL_INPUT = " p/3094 e/email@com ah/homeaddress";
+    static final String VALID_PARTIAL_INPUT = " n/adam";
     static final String BAD_FIELDS_INPUT = " n/adam p/badnumber e/email@com ah/homeaddress as/selladdress i/info";
     static final String VALID_INPUT = " n/Alice Pauline p/94351253 e/alice@example.com "
             + "ah/123, Jurong West Ave 6, #08-111 as/Selling address example i/Has Good Views t/friends";
@@ -25,9 +30,21 @@ public class AddSellerCommandParserTest {
     }
 
     @Test
+    public void assertPassesParse_invalidPartialInput() {
+        assertParseFailure(parser, INVALID_PARTIAL_INPUT,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSellerCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void assertFailsParse_badFieldsInput() {
         assertParseFailure(parser, BAD_FIELDS_INPUT,
                 String.format(Phone.MESSAGE_CONSTRAINTS, AddSellerCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void assertPassesParse_validPartialInput() {
+        assertParseSuccess(parser, VALID_PARTIAL_INPUT,
+                new AddSellerCommand(new SellerBuilder().withName("adam").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddSellerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSellerCommandParserTest.java
@@ -25,12 +25,6 @@ public class AddSellerCommandParserTest {
     }
 
     @Test
-    public void assertFailsParse_partialInput() {
-        assertParseFailure(parser, PARTIAL_INPUT,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSellerCommand.MESSAGE_USAGE));
-    }
-
-    @Test
     public void assertFailsParse_badFieldsInput() {
         assertParseFailure(parser, BAD_FIELDS_INPUT,
                 String.format(Phone.MESSAGE_CONSTRAINTS, AddSellerCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -33,12 +33,12 @@ public class ArgumentTokenizerTest {
 
     /**
      * Asserts all the arguments in {@code argMultimap} with {@code prefix} match the {@code expectedValues}
-     * and only the last value is returned upon calling {@code ArgumentMultimap#getValue(Prefix)}.
+     * and only the last value is returned upon calling {@code ArgumentMultimap#getValueOrDefault(Prefix)}.
      */
     private void assertArgumentPresent(ArgumentMultimap argMultimap, Prefix prefix, String... expectedValues) {
 
         // Verify the last value is returned
-        assertEquals(expectedValues[expectedValues.length - 1], argMultimap.getValue(prefix).get());
+        assertEquals(expectedValues[expectedValues.length - 1], argMultimap.getValueOrDefault(prefix, ""));
 
         // Verify the number of values returned is as expected
         assertEquals(expectedValues.length, argMultimap.getAllValues(prefix).size());
@@ -50,7 +50,7 @@ public class ArgumentTokenizerTest {
     }
 
     private void assertArgumentAbsent(ArgumentMultimap argMultimap, Prefix prefix) {
-        assertFalse(argMultimap.getValue(prefix).isPresent());
+        assertFalse(argMultimap.getValueOrDefault(prefix, "") != "");
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/BuyerBuilder.java
+++ b/src/test/java/seedu/address/testutil/BuyerBuilder.java
@@ -12,7 +12,7 @@ import seedu.address.model.util.SampleDataUtil;
  * Builds a buyer.
  */
 public class BuyerBuilder extends PersonBuilder {
-    public static final String DEFAULT_INFO = "Central Area 5 Room Condominium";
+    public static final String DEFAULT_INFO = "Placeholder house";
 
     private HouseInfo houseInfo;
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -18,9 +18,9 @@ import seedu.address.model.util.SampleDataUtil;
 public abstract class PersonBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
-    public static final String DEFAULT_PHONE = "85355255";
-    public static final String DEFAULT_EMAIL = "amy@gmail.com";
-    public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_PHONE = "123";
+    public static final String DEFAULT_EMAIL = "default@email.com";
+    public static final String DEFAULT_ADDRESS = "Placeholder Street, Singapore";
     public static final String DEFAULT_PRIORITY = "nil";
 
     // Set to package private

--- a/src/test/java/seedu/address/testutil/SellerBuilder.java
+++ b/src/test/java/seedu/address/testutil/SellerBuilder.java
@@ -14,8 +14,8 @@ import seedu.address.model.util.SampleDataUtil;
  */
 public class SellerBuilder extends PersonBuilder {
 
-    public static final String DEFAULT_SELLING_ADDRESS = "47D Lor Sarhad, Singapore 119164";
-    public static final String DEFAULT_INFO = "4 Room Flat in Sarhad Ville";
+    public static final String DEFAULT_SELLING_ADDRESS = "Placeholder Street, Singapore";
+    public static final String DEFAULT_INFO = "Placeholder house";
 
     private Address sellingAddress;
     private HouseInfo houseInfo;


### PR DESCRIPTION
Allows flexible filling such that adding buyers and sellers will only strictly require the name field, though remaining fields can nonetheless be filled in as desired. Since it is required to fill in the name, a default name is not provided.