### PR TITLE
[Fixes #134] Integrate CommandWarnings into Edit command parsers

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.CommandWarnings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -60,16 +61,18 @@ public class EditBuyerCommand extends Command {
 
     private final Index index;
     private final EditBuyerDescriptor editBuyerDescriptor;
+    private final CommandWarnings commandWarnings;
 
     /**
      * @param index of the buyer in the filtered buyer list to edit
      * @param editBuyerDescriptor details to edit the buyer with
      */
-    public EditBuyerCommand(Index index, EditBuyerDescriptor editBuyerDescriptor) {
+    public EditBuyerCommand(Index index, EditBuyerDescriptor editBuyerDescriptor, CommandWarnings commandWarnings) {
         requireNonNull(index);
         requireNonNull(editBuyerDescriptor);
         this.index = index;
         this.editBuyerDescriptor = new EditBuyerDescriptor(editBuyerDescriptor);
+        this.commandWarnings = commandWarnings;
     }
 
     @Override
@@ -90,6 +93,10 @@ public class EditBuyerCommand extends Command {
 
         model.setBuyer(buyerToEdit, editedBuyer);
         model.updateFilteredBuyerList(PREDICATE_SHOW_BUYERS);
+
+        if (commandWarnings.containsWarnings()) {
+            return new CommandResult(commandWarnings.getWarningMessage());
+        }
         return new CommandResult(String.format(MESSAGE_EDIT_BUYER_SUCCESS, Messages.format(editedBuyer)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.CommandWarnings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -62,16 +63,18 @@ public class EditSellerCommand extends Command {
 
     private final Index index;
     private final EditSellerDescriptor editSellerDescriptor;
+    private final CommandWarnings commandWarnings;
 
     /**
      * @param index of the seller in the filtered seller list to edit
      * @param editSellerDescriptor details to edit the seller with
      */
-    public EditSellerCommand(Index index, EditSellerDescriptor editSellerDescriptor) {
+    public EditSellerCommand(Index index, EditSellerDescriptor editSellerDescriptor, CommandWarnings commandWarnings) {
         requireNonNull(index);
         requireNonNull(editSellerDescriptor);
         this.index = index;
         this.editSellerDescriptor = new EditSellerDescriptor(editSellerDescriptor);
+        this.commandWarnings = commandWarnings;
     }
 
     @Override
@@ -92,6 +95,9 @@ public class EditSellerCommand extends Command {
 
         model.setSeller(sellerToEdit, editedSeller);
         model.updateFilteredSellerList(PREDICATE_SHOW_SELLERS);
+        if (commandWarnings.containsWarnings()) {
+            return new CommandResult(commandWarnings.getWarningMessage());
+        }
         return new CommandResult(String.format(MESSAGE_EDIT_SELLER_SUCCESS, Messages.format(editedSeller)));
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -98,10 +98,10 @@ public class AddressBookParser {
             return new SetSellerPriorityCommandParser().parse(arguments, commandWarnings);
 
         case EditBuyerCommand.COMMAND_WORD:
-            return new EditBuyerCommandParser().parse(arguments);
+            return new EditBuyerCommandParser().parse(arguments, commandWarnings);
 
         case EditSellerCommand.COMMAND_WORD:
-            return new EditSellerCommandParser().parse(arguments);
+            return new EditSellerCommandParser().parse(arguments, commandWarnings);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import seedu.address.logic.Messages;
@@ -41,6 +42,15 @@ public class ArgumentMultimap {
         List<String> values = getAllValues(prefix);
         return !values.isEmpty() && values.get(values.size() - 1) != null
                 && !values.get(values.size() - 1).trim().isEmpty() ? values.get(values.size() - 1) : defaultString;
+    }
+
+
+    /**
+     * Returns the last value of {@code prefix}.
+     */
+    public Optional<String> getValue(Prefix prefix) {
+        List<String> values = getAllValues(prefix);
+        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditBuyerCommandParser.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandWarnings;
 import seedu.address.logic.commands.EditBuyerCommand;
 import seedu.address.logic.commands.EditBuyerCommand.EditBuyerDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -31,7 +32,7 @@ public class EditBuyerCommandParser implements Parser<EditBuyerCommand> {
      * and returns an EditBuyerCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public EditBuyerCommand parse(String args) throws ParseException {
+    public EditBuyerCommand parse(String args, CommandWarnings commandWarnings) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_HOUSE_INFO,
@@ -51,30 +52,35 @@ public class EditBuyerCommandParser implements Parser<EditBuyerCommand> {
         EditBuyerDescriptor editBuyerDescriptor = new EditBuyerDescriptor();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editBuyerDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            editBuyerDescriptor.setName(ParserUtil.parseName(commandWarnings, argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editBuyerDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+            editBuyerDescriptor.setPhone(ParserUtil.parsePhone(commandWarnings,
+                    argMultimap.getValue(PREFIX_PHONE).get()));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editBuyerDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            editBuyerDescriptor.setEmail(ParserUtil.parseEmail(commandWarnings,
+                    argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editBuyerDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            editBuyerDescriptor.setAddress(ParserUtil.parseAddress(commandWarnings,
+                    argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_HOUSE_INFO).isPresent()) {
-            editBuyerDescriptor.setHouseInfo(ParserUtil.parseHouseInfo(argMultimap.getValue(PREFIX_HOUSE_INFO).get()));
+            editBuyerDescriptor.setHouseInfo(ParserUtil.parseHouseInfo(commandWarnings,
+                    argMultimap.getValue(PREFIX_HOUSE_INFO).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editBuyerDescriptor::setTags);
+        parseTagsForEdit(commandWarnings, argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editBuyerDescriptor::setTags);
         if (argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
-            editBuyerDescriptor.setPriority(ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).get()));
+            editBuyerDescriptor.setPriority(ParserUtil.parsePriority(commandWarnings,
+                    argMultimap.getValue(PREFIX_PRIORITY).get()));
         }
 
         if (!editBuyerDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditBuyerCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditBuyerCommand(index, editBuyerDescriptor);
+        return new EditBuyerCommand(index, editBuyerDescriptor, commandWarnings);
     }
 
     /**
@@ -82,14 +88,15 @@ public class EditBuyerCommandParser implements Parser<EditBuyerCommand> {
      * If {@code tags} contain only one element which is an empty string, it will be parsed into a
      * {@code Set<Tag>} containing zero tags.
      */
-    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+    private Optional<Set<Tag>> parseTagsForEdit(CommandWarnings commandWarnings, Collection<String> tags)
+            throws ParseException {
         assert tags != null;
 
         if (tags.isEmpty()) {
             return Optional.empty();
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
+        return Optional.of(ParserUtil.parseTags(commandWarnings, tagSet));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditSellerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditSellerCommandParser.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandWarnings;
 import seedu.address.logic.commands.EditSellerCommand;
 import seedu.address.logic.commands.EditSellerCommand.EditSellerDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -32,7 +33,7 @@ public class EditSellerCommandParser implements Parser<EditSellerCommand> {
      * and returns an EditSellerCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public EditSellerCommand parse(String args) throws ParseException {
+    public EditSellerCommand parse(String args, CommandWarnings commandWarnings) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
@@ -53,33 +54,41 @@ public class EditSellerCommandParser implements Parser<EditSellerCommand> {
         EditSellerDescriptor editSellerDescriptor = new EditSellerDescriptor();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editSellerDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            editSellerDescriptor.setName(ParserUtil.parseName(commandWarnings,
+                    argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editSellerDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+            editSellerDescriptor.setPhone(ParserUtil.parsePhone(commandWarnings,
+                    argMultimap.getValue(PREFIX_PHONE).get()));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editSellerDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            editSellerDescriptor.setEmail(ParserUtil.parseEmail(commandWarnings,
+                    argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editSellerDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            editSellerDescriptor.setAddress(ParserUtil.parseAddress(commandWarnings,
+                    argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_SELLING_ADDRESS).isPresent()) {
-            editSellerDescriptor.setSellingAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            editSellerDescriptor.setSellingAddress(ParserUtil.parseAddress(commandWarnings,
+                    argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_HOUSE_INFO).isPresent()) {
-            editSellerDescriptor.setHouseInfo(ParserUtil.parseHouseInfo(argMultimap.getValue(PREFIX_HOUSE_INFO).get()));
+            editSellerDescriptor.setHouseInfo(ParserUtil.parseHouseInfo(commandWarnings,
+                    argMultimap.getValue(PREFIX_HOUSE_INFO).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editSellerDescriptor::setTags);
+        parseTagsForEdit(commandWarnings, argMultimap.getAllValues(PREFIX_TAG))
+                .ifPresent(editSellerDescriptor::setTags);
         if (argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
-            editSellerDescriptor.setPriority(ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).get()));
+            editSellerDescriptor.setPriority(ParserUtil.parsePriority(commandWarnings,
+                    argMultimap.getValue(PREFIX_PRIORITY).get()));
         }
 
         if (!editSellerDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditSellerCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditSellerCommand(index, editSellerDescriptor);
+        return new EditSellerCommand(index, editSellerDescriptor, commandWarnings);
     }
 
     /**
@@ -87,14 +96,15 @@ public class EditSellerCommandParser implements Parser<EditSellerCommand> {
      * If {@code tags} contain only one element which is an empty string, it will be parsed into a
      * {@code Set<Tag>} containing zero tags.
      */
-    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+    private Optional<Set<Tag>> parseTagsForEdit(CommandWarnings commandWarnings, Collection<String> tags)
+            throws ParseException {
         assert tags != null;
 
         if (tags.isEmpty()) {
             return Optional.empty();
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
+        return Optional.of(ParserUtil.parseTags(commandWarnings, tagSet));
     }
 
 }


### PR DESCRIPTION
CommandWarnings help to warn of inappropriate inputs

As a step towards warnings users of inappropriate inputs,  let's take CommandWarnings as an argument for our edit command parsers. Doing so will help guide the user to use our app properly.