### PR TITLE
[#144] Improve command typability and case insensitivity

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteBuyerCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.displayable.buyer.Buyer;
  */
 public class DeleteBuyerCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete-b";
+    public static final String COMMAND_WORD = "bdelete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the buyer identified by the index number used in the displayed buyer list.\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteSellerCommand.java
@@ -18,7 +18,7 @@ import seedu.address.model.displayable.seller.Seller;
  */
 public class DeleteSellerCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete-s";
+    public static final String COMMAND_WORD = "sdelete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the seller identified by the index number used in the displayed seller list.\n"

--- a/src/main/java/seedu/address/logic/commands/ListBuyersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListBuyersCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
  */
 public class ListBuyersCommand extends Command {
 
-    public static final String COMMAND_WORD = "list-b";
+    public static final String COMMAND_WORD = "blist";
     public static final String MESSAGE_SUCCESS = "Listed all buyers";
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListSellersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListSellersCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
  */
 public class ListSellersCommand extends Command {
 
-    public static final String COMMAND_WORD = "list-s";
+    public static final String COMMAND_WORD = "slist";
     public static final String MESSAGE_SUCCESS = "Listed all sellers";
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SetBuyerPriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetBuyerPriorityCommand.java
@@ -18,7 +18,7 @@ import seedu.address.model.displayable.buyer.Buyer;
  */
 public class SetBuyerPriorityCommand extends Command {
 
-    public static final String COMMAND_WORD = "priority-b";
+    public static final String COMMAND_WORD = "bpriority";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Sets a priority level for the buyer, identified by index in the displayed buyer list. "

--- a/src/main/java/seedu/address/logic/commands/SetSellerPriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetSellerPriorityCommand.java
@@ -20,7 +20,7 @@ import seedu.address.model.displayable.seller.Seller;
  */
 public class SetSellerPriorityCommand extends Command {
 
-    public static final String COMMAND_WORD = "priority-s";
+    public static final String COMMAND_WORD = "spriority";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Sets a priority level for the seller, identified by index in the displayed seller list. "

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -57,7 +57,7 @@ public class AddressBookParser {
         // Lower level log messages are used sparingly to minimize noise in the code.
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
 
-        switch (commandWord) {
+        switch (commandWord.toLowerCase()) {
 
         case AddBuyerCommand.COMMAND_WORD:
             return new AddBuyerCommandParser().parse(arguments, commandWarnings);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.DeleteBuyerCommand;
+import seedu.address.logic.commands.DeleteSellerCommand;
 import seedu.address.logic.commands.ListSellersCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -54,7 +56,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete-b 9";
+        String deleteCommand = DeleteBuyerCommand.COMMAND_WORD + " 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_BUYER_DISPLAYED_INDEX);
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.DeleteBuyerCommand;
-import seedu.address.logic.commands.DeleteSellerCommand;
 import seedu.address.logic.commands.ListSellersCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -131,4 +131,15 @@ public class AddressBookParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
+
+    @Test
+    public void parseCommand_checkCaseInsensitivity() throws Exception {
+        assertTrue(parser.parseCommand(ListBuyersCommand.COMMAND_WORD.toLowerCase()) instanceof ListBuyersCommand);
+        assertTrue(parser.parseCommand(ListBuyersCommand.COMMAND_WORD.toLowerCase() + " 3")
+                instanceof ListBuyersCommand);
+        assertTrue(parser.parseCommand(ListBuyersCommand.COMMAND_WORD.toUpperCase()) instanceof ListBuyersCommand);
+        assertTrue(parser.parseCommand(ListBuyersCommand.COMMAND_WORD.toUpperCase() + " 3")
+                instanceof ListBuyersCommand);
+    }
+
 }


### PR DESCRIPTION
Allow command words to be typed without hyphens and ignoring case. TODO: ensure fields and prefixes are appropriately case-insensitive or sensitive. Addresses #144.