### PR TITLE
[Closes #133] Add warning for same name in buyer & seller list

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,6 +22,11 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%d buyer(s) and %d seller(s) listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_POTENTIAL_DUPLICATE_BUYER = "This seller potentially also exists in the"
+            + " buyer list: If so, please verify that their contact information is the same";
+
+    public static final String MESSAGE_POTENTIAL_DUPLICATE_SELLER = "This buyer potentially also exists in the"
+            + " seller list: If so, please verify that their contact information is the same";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_POTENTIAL_DUPLICATE_SELLER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSE_INFO;
@@ -39,9 +40,6 @@ public class AddBuyerCommand extends Command {
             + PREFIX_TAG + "owesMoney";
     public static final String MESSAGE_SUCCESS = "Got it. I've added a buyer contact:\n%1$s";
     public static final String MESSAGE_DUPLICATE_BUYER = "This buyer already exists in the address book";
-    public static final String MESSAGE_POTENTIAL_DUPLICATE_SELLER = "This buyer potentially also exists in the"
-            + " seller list: If so, please verify that their contact information is the same";
-
     private final Buyer toAdd;
     private final CommandWarnings commandWarnings;
 

--- a/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
@@ -21,7 +21,6 @@ import seedu.address.model.displayable.buyer.Buyer;
 public class AddBuyerCommand extends Command {
 
     public static final String COMMAND_WORD = "buyer";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a buyer to the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
@@ -38,9 +37,10 @@ public class AddBuyerCommand extends Command {
             + PREFIX_HOUSE_INFO + "Central Area 5 Room Condominium "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
-
     public static final String MESSAGE_SUCCESS = "Got it. I've added a buyer contact:\n%1$s";
     public static final String MESSAGE_DUPLICATE_BUYER = "This buyer already exists in the address book";
+    public static final String MESSAGE_POTENTIAL_DUPLICATE_SELLER = "This buyer potentially also exists in the"
+            + " seller list: If so, please verify that their contact information is the same";
 
     private final Buyer toAdd;
     private final CommandWarnings commandWarnings;
@@ -64,11 +64,12 @@ public class AddBuyerCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
         if (model.hasBuyer(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_BUYER);
         }
-
+        if (model.buyerHasSameSellerName(toAdd)) {
+            commandWarnings.addWarning(MESSAGE_POTENTIAL_DUPLICATE_SELLER);
+        }
         model.addBuyer(toAdd);
         if (commandWarnings.containsWarnings()) {
             return new CommandResult(commandWarnings.getWarningMessage());

--- a/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_POTENTIAL_DUPLICATE_BUYER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSE_INFO;
@@ -44,8 +45,7 @@ public class AddSellerCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Got it. I've added a seller contact:\n%1$s";
     public static final String MESSAGE_DUPLICATE_SELLER = "This seller already exists in the address book";
-    public static final String MESSAGE_POTENTIAL_DUPLICATE_BUYER = "This seller potentially also exists in the"
-            + " buyer list: If so, please verify that their contact information is the same";
+
 
     private final Seller toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
@@ -44,6 +44,8 @@ public class AddSellerCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Got it. I've added a seller contact:\n%1$s";
     public static final String MESSAGE_DUPLICATE_SELLER = "This seller already exists in the address book";
+    public static final String MESSAGE_POTENTIAL_DUPLICATE_BUYER = "This seller potentially also exists in the"
+            + " buyer list: If so, please verify that their contact information is the same";
 
     private final Seller toAdd;
 
@@ -65,9 +67,11 @@ public class AddSellerCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
         if (model.hasSeller(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_SELLER);
+        }
+        if (model.sellerHasSameBuyerName(toAdd)) {
+            commandWarnings.addWarning(MESSAGE_POTENTIAL_DUPLICATE_BUYER);
         }
         if (commandWarnings.containsWarnings()) {
             return new CommandResult(commandWarnings.getWarningMessage());

--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -58,6 +58,8 @@ public class EditBuyerCommand extends Command {
     public static final String MESSAGE_EDIT_BUYER_SUCCESS = "Edited Buyer: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_BUYER = "This buyer already exists in the address book.";
+    public static final String MESSAGE_POTENTIAL_DUPLICATE_SELLER = "This buyer potentially also exists in the"
+            + " seller list: If so, please verify that their contact information is the same";
 
     private final Index index;
     private final EditBuyerDescriptor editBuyerDescriptor;
@@ -89,6 +91,9 @@ public class EditBuyerCommand extends Command {
 
         if (!buyerToEdit.isSamePerson(editedBuyer) && model.hasBuyer(editedBuyer)) {
             throw new CommandException(MESSAGE_DUPLICATE_BUYER);
+        }
+        if (model.buyerHasSameSellerName(editedBuyer)) {
+            commandWarnings.addWarning(MESSAGE_POTENTIAL_DUPLICATE_SELLER);
         }
 
         model.setBuyer(buyerToEdit, editedBuyer);

--- a/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditBuyerCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_POTENTIAL_DUPLICATE_SELLER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSE_INFO;
@@ -54,12 +55,10 @@ public class EditBuyerCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
-
     public static final String MESSAGE_EDIT_BUYER_SUCCESS = "Edited Buyer: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_BUYER = "This buyer already exists in the address book.";
-    public static final String MESSAGE_POTENTIAL_DUPLICATE_SELLER = "This buyer potentially also exists in the"
-            + " seller list: If so, please verify that their contact information is the same";
+    public static final String MESSAGE_DUPLICATE_BUYER = "This buyer already exists in the address book";
+
 
     private final Index index;
     private final EditBuyerDescriptor editBuyerDescriptor;

--- a/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_POTENTIAL_DUPLICATE_BUYER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HOUSE_INFO;
@@ -59,10 +60,7 @@ public class EditSellerCommand extends Command {
 
     public static final String MESSAGE_EDIT_SELLER_SUCCESS = "Edited Seller: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_SELLER = "This seller already exists in the address book.";
-    public static final String MESSAGE_POTENTIAL_DUPLICATE_BUYER = "This buyer potentially also exists in the"
-            + " seller list: If so, please verify that their contact information is the same";
-
+    public static final String MESSAGE_DUPLICATE_SELLER = "This seller already exists in the address book";
     private final Index index;
     private final EditSellerDescriptor editSellerDescriptor;
     private final CommandWarnings commandWarnings;

--- a/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSellerCommand.java
@@ -60,6 +60,8 @@ public class EditSellerCommand extends Command {
     public static final String MESSAGE_EDIT_SELLER_SUCCESS = "Edited Seller: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_SELLER = "This seller already exists in the address book.";
+    public static final String MESSAGE_POTENTIAL_DUPLICATE_BUYER = "This buyer potentially also exists in the"
+            + " seller list: If so, please verify that their contact information is the same";
 
     private final Index index;
     private final EditSellerDescriptor editSellerDescriptor;
@@ -91,6 +93,9 @@ public class EditSellerCommand extends Command {
 
         if (!sellerToEdit.isSamePerson(editedSeller) && model.hasSeller(editedSeller)) {
             throw new CommandException(MESSAGE_DUPLICATE_SELLER);
+        }
+        if (model.sellerHasSameBuyerName(sellerToEdit)) {
+            commandWarnings.addWarning(MESSAGE_POTENTIAL_DUPLICATE_BUYER);
         }
 
         model.setSeller(sellerToEdit, editedSeller);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -86,11 +86,17 @@ public class AddressBook implements ReadOnlyAddressBook {
         return sellers.contains(seller);
     }
 
+    /**
+     * Returns true if a buyer has the same name as a seller in the address book's seller list.
+     */
     public boolean buyerHasSameSellerName(Buyer buyer) {
         requireNonNull(buyer);
         return sellers.contains(buyer);
     }
 
+    /**
+     * Returns true if a seller has the same name as buyer in the address book's buyer list.
+     */
     public boolean sellerHasSameBuyerName(Seller seller) {
         requireNonNull(seller);
         return buyers.contains(seller);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -86,6 +86,16 @@ public class AddressBook implements ReadOnlyAddressBook {
         return sellers.contains(seller);
     }
 
+    public boolean buyerHasSameSellerName(Buyer buyer) {
+        requireNonNull(buyer);
+        return sellers.contains(buyer);
+    }
+
+    public boolean sellerHasSameBuyerName(Seller seller) {
+        requireNonNull(seller);
+        return buyers.contains(seller);
+    }
+
     /**
      * Adds a buyer to the address book's buyer list.
      * The buyer must not already exist in the buyer list.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -70,6 +70,10 @@ public interface Model {
      */
     boolean hasSeller(Seller seller);
 
+    boolean buyerHasSameSellerName(Buyer buyer);
+
+    boolean sellerHasSameBuyerName(Seller seller);
+
     /**
      * Deletes the given buyer.
      * The buyer must exist in the address book's buyer list.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.displayable.Person;
 import seedu.address.model.displayable.buyer.Buyer;
 import seedu.address.model.displayable.seller.Seller;
 
@@ -107,6 +108,18 @@ public class ModelManager implements Model {
     public boolean hasSeller(Seller seller) {
         requireNonNull(seller);
         return addressBook.hasSeller(seller);
+    }
+
+    @Override
+    public boolean buyerHasSameSellerName(Buyer buyer) {
+        requireNonNull(buyer);
+        return addressBook.buyerHasSameSellerName(buyer);
+    }
+
+    @Override
+    public boolean sellerHasSameBuyerName(Seller seller) {
+        requireNonNull(seller);
+        return addressBook.sellerHasSameBuyerName(seller);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,7 +13,6 @@ import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.displayable.Person;
 import seedu.address.model.displayable.buyer.Buyer;
 import seedu.address.model.displayable.seller.Seller;
 

--- a/src/main/java/seedu/address/model/displayable/Person.java
+++ b/src/main/java/seedu/address/model/displayable/Person.java
@@ -101,6 +101,7 @@ public abstract class Person implements Displayable {
                 && otherPerson.getName().equals(getName());
     }
 
+    @Override
     public boolean isSameDisplayable(Displayable displayable) {
         return ((displayable instanceof Person) && isSamePerson((Person) displayable));
     }

--- a/src/main/java/seedu/address/model/displayable/UniqueDisplayableList.java
+++ b/src/main/java/seedu/address/model/displayable/UniqueDisplayableList.java
@@ -31,7 +31,7 @@ public class UniqueDisplayableList<T extends Displayable> implements Iterable<T>
     /**
      * Returns true if the list contains an equivalent displayable as the given argument.
      */
-    public boolean contains(T toCheck) {
+    public boolean contains(Displayable toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameDisplayable);
     }

--- a/src/test/java/seedu/address/logic/commands/AddBuyerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddBuyerCommandTest.java
@@ -152,6 +152,16 @@ public class AddBuyerCommandTest {
         }
 
         @Override
+        public boolean buyerHasSameSellerName(Buyer buyer) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean sellerHasSameBuyerName(Seller seller) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteBuyer(Buyer target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddSellerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSellerCommandTest.java
@@ -152,6 +152,15 @@ public class AddSellerCommandTest {
         }
 
         @Override
+        public boolean buyerHasSameSellerName(Buyer buyer) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean sellerHasSameBuyerName(Seller seller) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
         public void deleteBuyer(Buyer target) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Namely modifies the Add and Edit Commands to warn the user of a potential duplicate by name across the buyer and seller list